### PR TITLE
fix: pointer move attempts to intersect geometries causing intense lag

### DIFF
--- a/packages/fiber/src/core/events.ts
+++ b/packages/fiber/src/core/events.ts
@@ -437,7 +437,7 @@ export function createEvents(store: UseBoundStore<RootState>) {
       const isClickEvent = name === 'onClick' || name === 'onContextMenu' || name === 'onDoubleClick'
       const filter = isPointerMove ? filterPointerEvents : undefined
 
-      const hits = intersect(event, filter)
+      const hits = isPointerMove ? [] : intersect(event, filter)
       const delta = isClickEvent ? calculateDistance(event) : 0
 
       // Save initial coordinates on pointer-down


### PR DESCRIPTION
After adding a OrbitControls to the canvas and loading a relatively big STL file (50mb). Performance is really bad when the pointer is moving over the geometry. 

Using Chrome's performance diagnostics tool, I found out that happens because this library attempts to intersect the geometry the pointer is on every pointer move event. Not sure if this is the correct solution, but it cancels the intersection calculations on pointer move.